### PR TITLE
Error handling

### DIFF
--- a/error_handling.go
+++ b/error_handling.go
@@ -1,0 +1,18 @@
+package capo
+
+import (
+	"net/http"
+)
+
+func ErrorHandling(ctx *Context) {
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		switch err := ctxErr.(type) {
+		case *ServerError:
+			ctx.Write(err)
+		default:
+			ctx.SetStatus(http.StatusInternalServerError)
+			ctx.Write(NewServerError(InternalServerErrorCode, err))
+		}
+	}
+}

--- a/generic/context.go
+++ b/generic/context.go
@@ -42,8 +42,9 @@ func (ctx *Context[T, U]) Value(key any) any {
 
 // Write marshals and write the information in the entity provided into the http
 // response.
-func (ctx *Context[T, U]) Write(entity *U) error {
-	return ctx.ctx.Write(entity)
+func (ctx *Context[T, U]) Write(entity *U) *Context[T, U] {
+	ctx.ctx.Write(entity)
+	return ctx
 }
 
 // Cancel sets the error in the context and cancel it.

--- a/group_test.go
+++ b/group_test.go
@@ -17,7 +17,7 @@ func TestGroupHandleGetRequest(t *testing.T) {
 
 	msg := "get test message"
 	group.Get("/", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 
@@ -44,7 +44,7 @@ func TestGroupHandlePostRequest(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, reqMsg, req.Message)
 
-		ctx.Status(http.StatusOK).Write(&TestData{Message: resMsg})
+		ctx.Write(&TestData{Message: resMsg})
 		return nil
 	})
 
@@ -71,7 +71,7 @@ func TestGroupHandlePutRequest(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, reqMsg, req.Message)
 
-		ctx.Status(http.StatusOK).Write(&TestData{Message: resMsg})
+		ctx.Write(&TestData{Message: resMsg})
 		return nil
 	})
 
@@ -91,7 +91,7 @@ func TestGroupHandleDeleteRequest(t *testing.T) {
 
 	msg := "delete request test"
 	group.Delete("/request", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 
@@ -111,7 +111,7 @@ func TestRequestGroupAndEndpointWithoutPath(t *testing.T) {
 
 	msg := "test request"
 	group.Get("", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 
@@ -131,7 +131,7 @@ func TestRequestGroupWithoutPathAndEndpointWithPath(t *testing.T) {
 
 	msg := "test request"
 	group.Get("endpoint-path", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 
@@ -151,7 +151,7 @@ func TestRequestGroupWithPathAndEndpointWithoutPath(t *testing.T) {
 
 	msg := "test request"
 	group.Get("", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 
@@ -171,7 +171,7 @@ func TestRequestGroupAndEndpointWithPath(t *testing.T) {
 
 	msg := "test request"
 	group.Get("endpoint-path", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 
@@ -203,7 +203,7 @@ func testRequestWithNLevelsOfGroups(t *testing.T, levels int) {
 
 	msg := "test request"
 	group.Get("", func(ctx *Context) error {
-		ctx.Status(http.StatusOK).Write(&TestData{Message: msg})
+		ctx.Write(&TestData{Message: msg})
 		return nil
 	})
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,13 @@ func New() *Server {
 	}
 }
 
+// Default returns a server with the default configuration.
+func Default() *Server {
+	s := New()
+	s.UseAfterAlways(ErrorHandling)
+	return s
+}
+
 // ServeHTTP implements "http.Handler" interface.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.r.ServeHTTP(w, r)

--- a/server_error.go
+++ b/server_error.go
@@ -1,0 +1,23 @@
+package capo
+
+import "fmt"
+
+var InternalServerErrorCode = "INTERNAL_ERROR"
+
+// ServerError represents a server error.
+type ServerError struct {
+	inner error
+	Code  string `json:"code"`
+}
+
+// NewServerError creates a new instance of server error entity.
+func NewServerError(code string, inner error) *ServerError {
+	return &ServerError{
+		inner: inner,
+		Code:  code,
+	}
+}
+
+func (e *ServerError) Error() string {
+	return fmt.Sprintf("%s - %s", e.Code, e.inner.Error())
+}


### PR DESCRIPTION
## What?

Create error handling middleware.

Other changes:

- Now the application runs all request flow before writing the response.
- New `Default` method to create a default server.
- The request flow now handles any panic to run the "after always" middlewares.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream.
